### PR TITLE
Fixed module exclusion

### DIFF
--- a/demo-server.js
+++ b/demo-server.js
@@ -34,22 +34,15 @@ function run(err, moduleServer) {
     path = path.replace(/^\//, '');
     var parts = path.split(/\//);
     var modules = decodeURIComponent(parts.shift()).split(/,/);
-    var options = {};
-    parts.forEach(function(part) {
-      var pair = part.split(/=/);
-      options[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
-    });
     var exclude = null;
-    if(options.exm) {
-      exclude = options.exm.split(/,/);
+    if (parts.length) {
+      exclude = decodeURIComponent(parts.shift()).split(/,/);
     }
     return moduleServer(modules, exclude, onJs, {
       createSourceMap: isSourceMapRequest,
       sourceMapSourceRootUrlPrefix: ORIGINAL_SOURCE_PATH_PREFIX,
       debug: true,
-      onLog: function() {
-        console.log(arguments);
-      }
+      onLog: console.log
     });
   }
 


### PR DESCRIPTION
- modules that were supposed to be excluded, were included anyway, because
  the exclude part of the url was not parsed properly.
- it's not clear to me what the `options` object and `options.exm` do
  specifically, as they are not used anywhere else in the project. I took a
  bold guess, figured it was an anomaly and removed it.